### PR TITLE
Restict versions and release as 1.4

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,15 +10,10 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          #- '1.0'
-          #- '1.1'
-          #- '1.2'
-          #- '1.3'
           - '1.4'
           - '1.5'
           - '1.6'
-          - '1.7-nightly'
-          - 'nightly'
+        # - '1.7-nightly' works last i checked but not final yet
         os:
           - ubuntu-latest
         arch:

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TestEnv"
 uuid = "1e6cf692-eddd-4d53-88a5-2d735e33781b"
-version = "1.0.0"
+version = "1.4.0"
 
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [compat]
 ChainRulesCore = "=1.0.2"
-julia = "1.4"
+julia = "~1.4, ~1.5, ~1.6"
 
 [extras]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"


### PR DESCRIPTION
@mmiller-max what do you think?
This initial release will support 1.4, 1.5, 1.6 and will be called TestEnv v1.4

This implements part of #4

Then we can fork off this later to release 1.0.x that supports julia 1.0, 
etc