### PR TITLE
Make a 1.1 only branch/release

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.1'
         os:
           - ubuntu-latest
         arch:

--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,13 @@
 name = "TestEnv"
 uuid = "1e6cf692-eddd-4d53-88a5-2d735e33781b"
-version = "1.0.0"
+version = "1.1.0"
 
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [compat]
 ChainRulesCore = "=1.0.2"
-julia = "~1.0"
+julia = "~1.1"
 
 [extras]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/common.jl
+++ b/src/common.jl
@@ -58,17 +58,16 @@ function get_test_dir(ctx::Context, pkgspec::Pkg.Types.PackageSpec)
     if is_project_uuid(ctx.env, pkgspec.uuid)
         pkgspec.version = ctx.env.pkg.version
         pkgfilepath = dirname(ctx.env.project_file)
-    else        
-        info = manifest_info(ctx.env, pkgspec.uuid)
-        if haskey(info, "git-tree-sha1")
-            pkgfilepath = find_installed(pkgspec.name, pkgspec.uuid, SHA1(info["git-tree-sha1"]))
-        elseif haskey(info, "path")
-            pkgfilepath =  project_rel_path(ctx, info["path"])
+    else
+        entry = manifest_info(ctx.env, pkgspec.uuid)
+        if entry.repo.tree_sha !== nothing
+            pkgfilepath = find_installed(pkgspec.name, pkgspec.uuid, entry.repo.tree_sha)
+        elseif entry.path !== nothing
+            pkgfilepath =  project_rel_path(ctx, entry.path)
         elseif pkgspec.uuid in keys(ctx.stdlibs)
             pkgfilepath = Pkg.Types.stdlib_path(pkgspec.name)
         else
             throw(TestEnvError("Could not find either `git-tree-sha1` or `path` for package $(pkgspec.name)"))
         end
     end
-    return joinpath(pkgfilepath, "test")
 end


### PR DESCRIPTION
This PR targets `release-1.1`
Which has been initialized to #10 
It isn't much changes to support 1.1 from that starting point.