### PR TITLE
Make a 1.3 only branch/release

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.1'
+          - '1.3'
         os:
           - ubuntu-latest
         arch:

--- a/Project.toml
+++ b/Project.toml
@@ -1,17 +1,21 @@
 name = "TestEnv"
 uuid = "1e6cf692-eddd-4d53-88a5-2d735e33781b"
-version = "1.1.0"
+version = "1.3.0"
 
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [compat]
 ChainRulesCore = "=1.0.2"
-julia = "~1.1"
+MCMCDiagnosticTools = "=0.1.0"
+YAXArrays = "0.1.3"
+julia = "~1.3"
 
 [extras]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+MCMCDiagnosticTools = "be115224-59cd-429b-ad48-344e309966f0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+YAXArrays = "c21b50f5-aa40-41ea-b809-c0f5e47bfa5c"
 
 [targets]
-test = ["ChainRulesCore", "Test"]
+test = ["ChainRulesCore", "MCMCDiagnosticTools", "Test", "YAXArrays"]

--- a/src/TestEnv.jl
+++ b/src/TestEnv.jl
@@ -1,11 +1,12 @@
 module TestEnv
 using Pkg
 using Pkg: PackageSpec
-using Pkg.Types: Context, ensure_resolved, is_project_uuid, SHA1
+using Pkg.Types: Context, ensure_resolved, is_project_uuid, write_env, is_stdlib
+using Pkg.Types: Types, projectfile_path, manifestfile_path
 using Pkg.Operations: manifest_info, manifest_resolve!, project_deps_resolve!
 using Pkg.Operations: project_rel_path, project_resolve!
-using Pkg.Operations: with_dependencies_loadable_at_toplevel, find_installed
-
+using Pkg.Operations: sandbox, source_path, sandbox_preserve, abspath!
+using Pkg.Operations: with_dependencies_loadable_at_toplevel, update_package_test!
 
 include("common.jl")
 include("activate_do.jl")

--- a/src/activate_set.jl
+++ b/src/activate_set.jl
@@ -10,10 +10,24 @@ function activate(pkg::AbstractString=current_pkg_name())
     outer_tmp = mktempdir()
 
     ctx, pkgspec = ctx_and_pkgspec(pkg)
-    get_test_dir(ctx, pkgspec)  # HACK: a side effect of this is to fix pkgspec
-    with_dependencies_loadable_at_toplevel(ctx, pkgspec; might_need_to_resolve=true) do localctx
-        cp(localctx.env.project_file, joinpath(outer_tmp, "Project.toml"))
-        cp(localctx.env.manifest_file, joinpath(outer_tmp, "Manifest.toml"))
+    if test_dir_has_project_file(ctx, pkgspec)
+        local final_dir
+        sandbox(ctx, pkgspec, pkgspec.path, joinpath(pkgspec.path, "test")) do
+            flush(stdout)
+            final_dir = dirname(Base.active_project())
+            cp(joinpath(final_dir, "Project.toml"), joinpath(outer_tmp, "Project.toml"))
+            cp(joinpath(final_dir, "Manifest.toml"), joinpath(outer_tmp, "Manifest.toml"))
+        end
+        # Trick the cache into not realizing that the directory was deleted
+        mv(outer_tmp, final_dir)
+        Pkg.activate(final_dir)
+    else
+        with_dependencies_loadable_at_toplevel(ctx, pkgspec; might_need_to_resolve=true) do localctx
+            flush(stdout)
+            cp(localctx.env.project_file, joinpath(outer_tmp, "Project.toml"))
+            cp(localctx.env.manifest_file, joinpath(outer_tmp, "Manifest.toml"))
+        end
+        Pkg.activate(outer_tmp)
     end
-    Pkg.activate(outer_tmp)
 end
+

--- a/test/activate_do.jl
+++ b/test/activate_do.jl
@@ -5,4 +5,12 @@
         end
         @test isdefined(@__MODULE__, :FiniteDifferences)
     end
+
+    @testset "activate do test/Project" begin
+        # MCMCDiagnosticTools has a test/Project.toml, which contains FFTW
+        TestEnv.activate("MCMCDiagnosticTools") do
+            @eval using FFTW
+        end
+        @test isdefined(@__MODULE__, :FFTW)
+    end
 end

--- a/test/activate_set.jl
+++ b/test/activate_set.jl
@@ -12,4 +12,19 @@
             Pkg.activate(orig_project_toml_path)
         end
     end
+
+    @testset "activate test/Project" begin
+        orig_project_toml_path = Base.active_project()
+        try
+            # YAXArrays has a test/Project.toml, which contains CSV
+            TestEnv.activate("YAXArrays")
+            new_project_toml_path = Base.active_project()
+            @test new_project_toml_path != orig_project_toml_path
+
+            @eval using CSV
+            @test isdefined(@__MODULE__, :CSV)
+        finally
+            Pkg.activate(orig_project_toml_path)
+        end
+    end
 end


### PR DESCRIPTION
This extends the trick used in 1.0 of copying the sandbox environment out  to work in 1.3+.
We *could* keep using that trick in all future versions, but I think it is uglier.
It activates the sandbox environment, updates it, activates the old environment, activates the sandbox environment again.
I think it is fine enough so we can support 1.3 (since it is a very common lower bound).
and it is minimal effort compared to workout out the 1.3 way to cut the sandbox in half.