### PR TITLE
Make a 1.2 only branch/release

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.3'
+          - '1.2'
         os:
           - ubuntu-latest
         arch:

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,6 @@ uuid = "1e6cf692-eddd-4d53-88a5-2d735e33781b"
 version = "1.2.0"
 
 [deps]
-ConstraintSolver = "e0e52ebd-5523-408d-9ca3-7641f1cd1405"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [compat]
@@ -12,8 +11,9 @@ ConstraintSolver = "=0.6.10"
 julia = "~1.2"
 
 [extras]
+ConstraintSolver = "e0e52ebd-5523-408d-9ca3-7641f1cd1405"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ChainRulesCore", "Test"]
+test = ["ChainRulesCore", "Test", "ConstraintSolver"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,21 +1,19 @@
 name = "TestEnv"
 uuid = "1e6cf692-eddd-4d53-88a5-2d735e33781b"
-version = "1.3.0"
+version = "1.2.0"
 
 [deps]
+ConstraintSolver = "e0e52ebd-5523-408d-9ca3-7641f1cd1405"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [compat]
 ChainRulesCore = "=1.0.2"
-MCMCDiagnosticTools = "=0.1.0"
-YAXArrays = "0.1.3"
-julia = "~1.3"
+ConstraintSolver = "=0.6.10"
+julia = "~1.2"
 
 [extras]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-MCMCDiagnosticTools = "be115224-59cd-429b-ad48-344e309966f0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-YAXArrays = "c21b50f5-aa40-41ea-b809-c0f5e47bfa5c"
 
 [targets]
-test = ["ChainRulesCore", "MCMCDiagnosticTools", "Test", "YAXArrays"]
+test = ["ChainRulesCore", "Test"]

--- a/src/activate_do.jl
+++ b/src/activate_do.jl
@@ -12,7 +12,7 @@ Indeed this is basically extracted from what `Pkg.test()` does.
 function activate(f, pkg::AbstractString=current_pkg_name())
     ctx, pkgspec = ctx_and_pkgspec(pkg)    
     if test_dir_has_project_file(ctx, pkgspec)
-        sandbox(ctx, pkgspec, pkgspec.path, joinpath(pkgspec.path, "test")) do
+        sandbox(ctx, pkgspec, pkgspec.path, sandbox_mutable_dir(pkgspec)) do
             flush(stdout)
             f()
         end

--- a/src/activate_set.jl
+++ b/src/activate_set.jl
@@ -12,7 +12,7 @@ function activate(pkg::AbstractString=current_pkg_name())
     ctx, pkgspec = ctx_and_pkgspec(pkg)
     if test_dir_has_project_file(ctx, pkgspec)
         local final_dir
-        sandbox(ctx, pkgspec, pkgspec.path, joinpath(pkgspec.path, "test")) do
+        sandbox(ctx, pkgspec, pkgspec.path, sandbox_mutable_dir(pkgspec)) do
             flush(stdout)
             final_dir = dirname(Base.active_project())
             cp(joinpath(final_dir, "Project.toml"), joinpath(outer_tmp, "Project.toml"))

--- a/src/common.jl
+++ b/src/common.jl
@@ -67,3 +67,18 @@ function get_test_dir(ctx::Context, pkgspec::Pkg.Types.PackageSpec)
     pkgfilepath = project_rel_path(ctx, source_path(pkgspec))
     return joinpath(pkgfilepath, "test")
 end
+
+
+function sandbox_mutable_dir(pkgspec)
+    # got to copy the project.toml from the test dir out somewhere else
+    # so can change there modes, so that can remove readonly flag so that when the
+    # the temp-env inside the sandbox creates a copy of them (again) that copy has the
+    # write permission.
+    sandbox_outer_dir = mktempdir()
+    cp(joinpath(pkgspec.path, "test", "Project.toml"), joinpath(sandbox_outer_dir, "Project.toml"))
+    if isfile(joinpath(pkgspec.path, "test", "Manifest.toml"))
+        cp(joinpath(pkgspec.path, "test", "Manifest.toml"), joinpath(sandbox_outer_dir, "Manifest.toml"))
+    end
+    chmod(sandbox_outer_dir, 0o700; recursive=true)
+    return sandbox_outer_dir
+end

--- a/test/activate_do.jl
+++ b/test/activate_do.jl
@@ -8,9 +8,9 @@
 
     @testset "activate do test/Project" begin
         # MCMCDiagnosticTools has a test/Project.toml, which contains FFTW
-        TestEnv.activate("MCMCDiagnosticTools") do
-            @eval using FFTW
+        TestEnv.activate("ConstraintSolver") do
+            @eval using Combinatorics
         end
-        @test isdefined(@__MODULE__, :FFTW)
+        @test isdefined(@__MODULE__, :Combinatorics)
     end
 end

--- a/test/activate_do.jl
+++ b/test/activate_do.jl
@@ -1,9 +1,11 @@
 @testset "activate_do.jl" begin
     @testset "activate do f [extras]" begin
+        orig_project = Base.active_project()
         TestEnv.activate("ChainRulesCore") do
             @eval using FiniteDifferences
         end
         @test isdefined(@__MODULE__, :FiniteDifferences)
+        @test Base.active_project() == orig_project
     end
 
     @testset "activate do test/Project" begin

--- a/test/activate_set.jl
+++ b/test/activate_set.jl
@@ -17,12 +17,12 @@
         orig_project_toml_path = Base.active_project()
         try
             # YAXArrays has a test/Project.toml, which contains CSV
-            TestEnv.activate("YAXArrays")
+            TestEnv.activate("ConstraintSolver")
             new_project_toml_path = Base.active_project()
             @test new_project_toml_path != orig_project_toml_path
 
-            @eval using CSV
-            @test isdefined(@__MODULE__, :CSV)
+            @eval using JSON
+            @test isdefined(@__MODULE__, :JSON)
         finally
             Pkg.activate(orig_project_toml_path)
         end


### PR DESCRIPTION
This was based on #13 so i have initialized release-1.2 to that.
A thing we need to do in 1.2 that we don't in 1.3 is make sure the sandbox override directory .toml files are writable.
Also had to replace the tests.
It is hard to find something that is 1.2 compatible and using `test/Project.toml`