### PR TITLE
Make example consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ julia> using TestEnv;
 
 julia> TestEnv.activate();
 
-julia> using ChainRulesCore
+julia> using ChainRulesTestUtils
 ```
 
 Use `Pkg.activate` to re-activate the previous environment, e.g. `Pkg.activate("~/.julia/dev/ChainRules")`.


### PR DESCRIPTION
This is the package mentioned above

> Consider for example **ChainRules.jl** has as a test-only dependency of **ChainRulesTestUtils.jl**,
not a main dependency
