### PR TITLE
Make activate set not mess with LOAD_PATH

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TestEnv"
 uuid = "1e6cf692-eddd-4d53-88a5-2d735e33781b"
-version = "1.7.0"
+version = "1.7.1"
 
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/src/activate_set.jl
+++ b/src/activate_set.jl
@@ -49,9 +49,7 @@ function activate(pkg::AbstractString=current_pkg_name())
 
     Types.write_manifest(working_manifest, tmp_manifest)
 
-    # sandbox
-    push!(empty!(LOAD_PATH), "@", tmp)
-    Base.ACTIVE_PROJECT[] = nothing
+    Base.ACTIVE_PROJECT[] = tmp_project
 
     temp_ctx = Context()
     temp_ctx.env.project.deps[pkgspec.name] = pkgspec.uuid
@@ -77,11 +75,6 @@ function activate(pkg::AbstractString=current_pkg_name())
         end
     end
     write_env(temp_ctx.env; update_undo=false)
-
-    # update enviroment variables
-    path_sep = Sys.iswindows() ? ';' : ':'
-    ENV["JULIA_LOAD_PATH"] = "@$(path_sep)$(tmp)"
-    delete!(ENV, "JULIA_PROJECT")
     
     return Base.active_project()
 end

--- a/test/activate_set.jl
+++ b/test/activate_set.jl
@@ -1,28 +1,40 @@
 @testset "activate_set.jl" begin
     @testset "activate [extras]" begin
         orig_project_toml_path = Base.active_project()
+        push!(LOAD_PATH, mktempdir())  # put something weird in LOAD_PATH for testing
+        orig_load_path = Base.LOAD_PATH
         try
             TestEnv.activate("ChainRulesCore")
             new_project_toml_path = Base.active_project()
             @test new_project_toml_path != orig_project_toml_path
+            @test orig_load_path == Base.LOAD_PATH
 
-            @eval using StaticArrays
+            @eval using StaticArrays  # From ChainRulesCore [extras] Project.toml
+            @test isdefined(@__MODULE__, :StaticArrays)
+
+            @eval using Compat  # from ChainRulesCore Project.toml
             @test isdefined(@__MODULE__, :StaticArrays)
         finally
             Pkg.activate(orig_project_toml_path)
+            # No longer is enviroment active
+            @test_throws ArgumentError @eval using OffsetArrays
         end
     end
 
     @testset "activate test/Project" begin
         orig_project_toml_path = Base.active_project()
+        push!(LOAD_PATH, mktempdir())  # put something weird in LOAD_PATH for testing
+        orig_load_path = Base.LOAD_PATH
         try
             # YAXArrays has a test/Project.toml, which contains CSV
             TestEnv.activate("YAXArrays")
             new_project_toml_path = Base.active_project()
             @test new_project_toml_path != orig_project_toml_path
+            @test orig_load_path == Base.LOAD_PATH
 
             @eval using CSV
             @test isdefined(@__MODULE__, :CSV)
+
         finally
             Pkg.activate(orig_project_toml_path)
         end


### PR DESCRIPTION
Should fix #19 .
Does fix it for me.

@nickrobinson251  do you want to take a look and see if it fixes?
This is the branch for julia 1.7, it will need porting to other banches after it is approved


A very nice side bonus of this approach is that `Pkg.activate("originalpath")` actually does indeed remove the test enviroment.
