### PR TITLE
Error when activating environment for unnamed project

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.7-nightly'
+          - '1.7'
         os:
           - ubuntu-latest
         arch:

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TestEnv"
 uuid = "1e6cf692-eddd-4d53-88a5-2d735e33781b"
-version = "1.7.3"
+version = "1.7.4"
 
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/src/common.jl
+++ b/src/common.jl
@@ -8,7 +8,7 @@ end
 
 function current_pkg_name()
     ctx = Context()
-    ctx.env.pkg === nothing && throw(TestEnvError("trying to test an unnamed project"))
+    ctx.env.pkg === nothing && throw(TestEnvError("trying to activate test environment of an unnamed project"))
     return ctx.env.pkg.name
 end
 

--- a/src/common.jl
+++ b/src/common.jl
@@ -6,8 +6,11 @@ function Base.showerror(io::IO, ex::TestEnvError, bt; backtrace=true)
     printstyled(io, ex.msg, color=Base.error_color())
 end
 
-
-current_pkg_name() = Context().env.pkg.name
+function current_pkg_name()
+    ctx = Context()
+    ctx.env.pkg === nothing && throw(TestEnvError("trying to test an unnamed project"))
+    return ctx.env.pkg.name
+end
 
 """
    ctx, pkgspec = ctx_and_pkgspec(pkg::AbstractString)

--- a/test/common.jl
+++ b/test/common.jl
@@ -1,0 +1,8 @@
+@testset "common.jl" begin
+    @testset "unnamed project" begin
+        original_project = Base.active_project()
+        Pkg.activate(@__DIR__)  # test folder is an unnamed project
+        @test_throws TestEnv.TestEnvError TestEnv.activate()
+        Pkg.activate(original_project)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using TestEnv
 using Test
 
 @testset "TestEnv.jl" begin
-    include("activate_do.jl")
-    include("activate_set.jl")
+    # include("activate_do.jl")
+    # include("activate_set.jl")
+    include("common.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using TestEnv
 using Test
 
 @testset "TestEnv.jl" begin
-    # include("activate_do.jl")
-    # include("activate_set.jl")
+    include("activate_do.jl")
+    include("activate_set.jl")
     include("common.jl")
 end


### PR DESCRIPTION
Before this PR, when activating the environment for an unnamed project, this is the error:

```
julia> TestEnv.activate() do;end
ERROR: type Nothing has no field name
```
After this PR:

```
julia> TestEnv.activate() do;end
ERROR: trying to test an unnamed project
```

This mirrors the approach in `Pkg` 