### PR TITLE
[Release-1.10] CI on all 1.10 prereleases or otherwise

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.10-nightly'
+          - '^1.10.0-0'
         os:
           - ubuntu-latest
         arch:


### PR DESCRIPTION
Read docs on https://github.com/julia-actions/setup-julia

saying `-nightly` will mean we have to update this once a actual `1.10` release comes out
this way doesn't. 
If I have done it right