### PR TITLE
Use trailing dash (e.g. `v"1.4-"`) to compare minor version numbers

### DIFF
--- a/src/TestEnv.jl
+++ b/src/TestEnv.jl
@@ -1,18 +1,18 @@
 module TestEnv
 
-@static if VERSION < v"1.1"
+@static if VERSION < v"1.1-"
     include("julia-1.0/TestEnv.jl")
-elseif VERSION < v"1.2"
+elseif VERSION < v"1.2-"
     include("julia-1.1/TestEnv.jl")
-elseif VERSION < v"1.3"
+elseif VERSION < v"1.3-"
     include("julia-1.2/TestEnv.jl")
-elseif VERSION < v"1.4"
+elseif VERSION < v"1.4-"
     include("julia-1.3/TestEnv.jl")
-elseif VERSION < v"1.7"
+elseif VERSION < v"1.7-"
     include("julia-1.4/TestEnv.jl")
-elseif VERSION < v"1.8"
+elseif VERSION < v"1.8-"
     include("julia-1.7/TestEnv.jl")
-elseif VERSION < v"1.9"
+elseif VERSION < v"1.9-"
     include("julia-1.8/TestEnv.jl")
 else
     include("julia-1.9/TestEnv.jl")

--- a/test/activate_do.jl
+++ b/test/activate_do.jl
@@ -6,7 +6,7 @@
 
             orig_project = Base.active_project()
 
-            if VERSION >= v"1.4"
+            if VERSION >= v"1.4-"
                 direct_deps() = [v.name for (_,v) in Pkg.dependencies() if v.is_direct_dep]
                 crc_deps = TestEnv.activate(direct_deps, "ChainRulesCore")
                 @test "ChainRulesCore" ∈ crc_deps
@@ -20,7 +20,7 @@
             
             # We use endswith here because on MacOS GitHub runners for some reasons the paths are slightly different
             # We also skip on Julia 1.2 and 1.3 on Windows because it is using 8 character shortened paths in one case
-            if !((v"1.2" <= VERSION < v"1.4") && Sys.iswindows())
+            if !((v"1.2-" <= VERSION < v"1.4-") && Sys.iswindows())
                 @test endswith(Base.active_project(), orig_project)
             end
         end
@@ -30,7 +30,7 @@
         mktempdir() do p
             Pkg.activate(p)
 
-            if VERSION >= v"1.4"
+            if VERSION >= v"1.4-"
                 Pkg.add(PackageSpec(name="MCMCDiagnosticTools", version="0.1.0"))
 
                 orig_project = Base.active_project()
@@ -42,7 +42,7 @@
                 @test isdefined(@__MODULE__, :FFTW)
                 
                 @test endswith(Base.active_project(), orig_project)
-            elseif VERSION >= v"1.2"
+            elseif VERSION >= v"1.2-"
                 Pkg.add(PackageSpec(name="ConstraintSolver", version="0.6.10"))
 
                 orig_project = Base.active_project()

--- a/test/activate_set.jl
+++ b/test/activate_set.jl
@@ -30,7 +30,7 @@
         mktempdir() do p
             Pkg.activate(p)
 
-            if VERSION >= v"1.4"
+            if VERSION >= v"1.4-"
                 Pkg.add(PackageSpec(name="YAXArrays", version="0.1.3"))
 
                 orig_project_toml_path = Base.active_project()
@@ -49,7 +49,7 @@
                 finally
                     Pkg.activate(orig_project_toml_path)
                 end
-            elseif VERSION >= v"1.2"
+            elseif VERSION >= v"1.2-"
                 Pkg.add(PackageSpec(name="ConstraintSolver", version="0.6.10"))
 
                 orig_project_toml_path = Base.active_project()
@@ -71,7 +71,7 @@
             end
         end
 
-        if VERSION >= v"1.4"
+        if VERSION >= v"1.4-"
             # https://github.com/JuliaTesting/TestEnv.jl/issues/26
             @test isdefined(TestEnv, :isfixed)
         end


### PR DESCRIPTION
This PR changes minor version checks such as `VERSION >= v"1.4"` (intended to match versions in the 1.4 series and beyond) to use Julia's trailing dash syntax: `VERSION >= v"1.4-"`.

The trailing dash is necessary for Julia's implementation of semver because `VERSION >= v"1.4"` will return `false` for alpha, beta, and rc versions that are part of the 1.4 series (and therefore have the same features):

```julia
julia> v"1.4-rc1" >= v"1.4-"
true

julia> v"1.4-rc1" >= v"1.4"
false
```

Reference: https://docs.julialang.org/en/v1/manual/strings/#man-version-number-literals

> It is good practice to use such special versions in comparisons (particularly, the trailing `-` should always be used on upper bounds unless there's a good reason not to)


----

This might fix https://github.com/JuliaTesting/TestEnv.jl/issues/35 and/or https://github.com/JuliaTesting/TestEnv.jl/issues/47.