### PR TITLE
support `re-resolve=false` on 1.8 and 1.9

### DIFF
--- a/src/julia-1.8/activate_do.jl
+++ b/src/julia-1.8/activate_do.jl
@@ -1,5 +1,5 @@
 """
-    TestEnv.activate(f, [pkg])
+    TestEnv.activate(f, [pkg]; allow_reresolve=true)
 
 Activate the test enviroment of `pkg` (defaults to current enviroment), and run `f()`,
 then deactivate the enviroment.
@@ -9,12 +9,12 @@ However, this *is* useful for anyone doing something like making a alternative t
 `Pkg.test()`.
 Indeed this is basically extracted from what `Pkg.test()` does.
 """
-function activate(f, pkg::AbstractString=current_pkg_name())
+function activate(f, pkg::AbstractString=current_pkg_name(); allow_reresolve=true)
     ctx, pkgspec = ctx_and_pkgspec(pkg)
-    
+
     test_project_override = maybe_gen_project_override!(ctx, pkgspec)
     path = pkgspec.path::String
-    return sandbox(ctx, pkgspec, path, joinpath(path, "test"), test_project_override) do
+    return sandbox(ctx, pkgspec, path, joinpath(path, "test"), test_project_override; allow_reresolve) do
         flush(stdout)
         f()
     end

--- a/src/julia-1.9/activate_do.jl
+++ b/src/julia-1.9/activate_do.jl
@@ -1,5 +1,5 @@
 """
-    TestEnv.activate(f, [pkg])
+    TestEnv.activate(f, [pkg]; allow_reresolve=true)
 
 Activate the test enviroment of `pkg` (defaults to current enviroment), and run `f()`,
 then deactivate the enviroment.
@@ -9,12 +9,12 @@ However, this *is* useful for anyone doing something like making a alternative t
 `Pkg.test()`.
 Indeed this is basically extracted from what `Pkg.test()` does.
 """
-function activate(f, pkg::AbstractString=current_pkg_name())
+function activate(f, pkg::AbstractString=current_pkg_name(); allow_reresolve=true)
     ctx, pkgspec = ctx_and_pkgspec(pkg)
-    
+
     test_project_override = maybe_gen_project_override!(ctx, pkgspec)
     path = pkgspec.path::String
-    return sandbox(ctx, pkgspec, path, joinpath(path, "test"), test_project_override) do
+    return sandbox(ctx, pkgspec, path, joinpath(path, "test"), test_project_override; allow_reresolve) do
         flush(stdout)
         f()
     end

--- a/test/activate_do.jl
+++ b/test/activate_do.jl
@@ -17,7 +17,7 @@
                 @eval using FiniteDifferences
             end
             @test isdefined(@__MODULE__, :FiniteDifferences)
-            
+
             # We use endswith here because on MacOS GitHub runners for some reasons the paths are slightly different
             # We also skip on Julia 1.2 and 1.3 on Windows because it is using 8 character shortened paths in one case
             if !((v"1.2-" <= VERSION < v"1.4-") && Sys.iswindows())
@@ -36,11 +36,11 @@
                 orig_project = Base.active_project()
 
                 # MCMCDiagnosticTools has a test/Project.toml, which contains FFTW
-                TestEnv.activate("MCMCDiagnosticTools") do
+                TestEnv.activate("MCMCDiagnosticTools"; allow_reresolve=false) do
                     @eval using FFTW
                 end
                 @test isdefined(@__MODULE__, :FFTW)
-                
+
                 @test endswith(Base.active_project(), orig_project)
             elseif VERSION >= v"1.2-"
                 Pkg.add(PackageSpec(name="ConstraintSolver", version="0.6.10"))
@@ -52,13 +52,13 @@
                     @eval using Combinatorics
                 end
                 @test isdefined(@__MODULE__, :Combinatorics)
-                
+
                 # We use endswith here because on MacOS GitHub runners for some reasons the paths are slightly different
                 # We also skip on Windows because it is using 8 character shortened paths in one case
                 if !Sys.iswindows()
                     @test endswith(Base.active_project(), orig_project)
                 end
-            end            
+            end
         end
     end
 end

--- a/test/activate_do.jl
+++ b/test/activate_do.jl
@@ -36,7 +36,12 @@
                 orig_project = Base.active_project()
 
                 # MCMCDiagnosticTools has a test/Project.toml, which contains FFTW
-                TestEnv.activate("MCMCDiagnosticTools"; allow_reresolve=false) do
+                if VERSION >= v"1.8-"
+                    kw = (; allow_reresolve=false)
+                else
+                    kw = NamedTuple()
+                end
+                TestEnv.activate("MCMCDiagnosticTools"; kw...) do
                     @eval using FFTW
                 end
                 @test isdefined(@__MODULE__, :FFTW)

--- a/test/activate_set.jl
+++ b/test/activate_set.jl
@@ -38,7 +38,7 @@
                 orig_load_path = Base.LOAD_PATH
                 try
                     # YAXArrays has a test/Project.toml, which contains CSV
-                    TestEnv.activate("YAXArrays")
+                    TestEnv.activate("YAXArrays"; allow_reresolve=false)
                     new_project_toml_path = Base.active_project()
                     @test new_project_toml_path != orig_project_toml_path
                     @test orig_load_path == Base.LOAD_PATH
@@ -57,7 +57,7 @@
                 orig_load_path = Base.LOAD_PATH
                 try
                     # ConstraintSolver has a test/Project.toml, which contains CSV
-                    TestEnv.activate("ConstraintSolver")
+                    TestEnv.activate("ConstraintSolver"; allow_reresolve=false)
                     new_project_toml_path = Base.active_project()
                     @test new_project_toml_path != orig_project_toml_path
                     @test orig_load_path == Base.LOAD_PATH

--- a/test/activate_set.jl
+++ b/test/activate_set.jl
@@ -38,7 +38,12 @@
                 orig_load_path = Base.LOAD_PATH
                 try
                     # YAXArrays has a test/Project.toml, which contains CSV
-                    TestEnv.activate("YAXArrays"; allow_reresolve=false)
+                    if VERSION >= v"1.8-"
+                        kw = (; allow_reresolve=false)
+                    else
+                        kw = NamedTuple()
+                    end
+                    TestEnv.activate("YAXArrays"; kw...)
                     new_project_toml_path = Base.active_project()
                     @test new_project_toml_path != orig_project_toml_path
                     @test orig_load_path == Base.LOAD_PATH
@@ -57,7 +62,12 @@
                 orig_load_path = Base.LOAD_PATH
                 try
                     # ConstraintSolver has a test/Project.toml, which contains CSV
-                    TestEnv.activate("ConstraintSolver"; allow_reresolve=false)
+                    if VERSION >= v"1.8-"
+                        kw = (; allow_reresolve=false)
+                    else
+                        kw = NamedTuple()
+                    end
+                    TestEnv.activate("ConstraintSolver"; kw...)
                     new_project_toml_path = Base.active_project()
                     @test new_project_toml_path != orig_project_toml_path
                     @test orig_load_path == Base.LOAD_PATH


### PR DESCRIPTION
closes https://github.com/JuliaTesting/TestEnv.jl/issues/82

* I do test the branch but not super effectively since I don't have a good example where it currently fails. It is a 1-line change (`allow_reresolve || rethrow()`) so it should be somewhat safe but it would still be better to have a test here.
* It is not clear to me how to bump the Project.toml version, a note on the versioning schema used here would be useful.
* Lastly, my editor is configured to remove trailing whitespace and to have a final `\n` at the end of a file. If this noise is too annoying I can try to fix it.