### PR TITLE
Remove the "absoluting stdlib paths" part

### DIFF
--- a/src/julia-1.9/activate_set.jl
+++ b/src/julia-1.9/activate_set.jl
@@ -69,12 +69,6 @@ function activate(pkg::AbstractString=current_pkg_name(); allow_reresolve=true)
         @debug "Using _clean_ dep graph"
     end
 
-    # Absolutify stdlibs paths
-    for (uuid, entry) in temp_ctx.env.manifest
-        if is_stdlib(uuid)
-            entry.path = Types.stdlib_path(entry.name::String)
-        end
-    end
     write_env(temp_ctx.env; update_undo=false)
 
     return Base.active_project()


### PR DESCRIPTION
This was already fixed in Pkg (https://github.com/JuliaLang/Pkg.jl/pull/3640) .

Shortly, writing out this explicit paths is not needed and it is also causing bugs with stdlib compat if you do Pkg operations with the TestEnv generated environment