### PR TITLE
Fix TestEnv for subpackages: precompile only the new test Project

### DIFF
--- a/src/julia-1.11/activate_set.jl
+++ b/src/julia-1.11/activate_set.jl
@@ -69,6 +69,11 @@ function activate(pkg::AbstractString=current_pkg_name(); allow_reresolve=true)
         @debug "Using _clean_ dep graph"
     end
 
+    # Now that we have set up the sandbox environment, precompile all its packages:
+    # (Reconnect the `io` back to the original context so the caller can see the
+    # precompilation progress.)
+    Pkg.precompile(temp_ctx; io=ctx.io)
+
     write_env(temp_ctx.env; update_undo=false)
 
     return Base.active_project()

--- a/src/julia-1.11/common.jl
+++ b/src/julia-1.11/common.jl
@@ -22,7 +22,7 @@ function ctx_and_pkgspec(pkg::AbstractString)
     pkgspec = deepcopy(PackageSpec(pkg))
     ctx = Context()
     isinstalled!(ctx, pkgspec) || throw(TestEnvError("$pkg not installed 👻"))
-    Pkg.instantiate(ctx)
+    Pkg.instantiate(ctx; allow_autoprecomp = false) # do precomp later within sandbox
     return ctx, pkgspec
 end
 

--- a/src/julia-1.9/activate_set.jl
+++ b/src/julia-1.9/activate_set.jl
@@ -69,6 +69,11 @@ function activate(pkg::AbstractString=current_pkg_name(); allow_reresolve=true)
         @debug "Using _clean_ dep graph"
     end
 
+    # Now that we have set up the sandbox environment, precompile all its packages:
+    # (Reconnect the `io` back to the original context so the caller can see the
+    # precompilation progress.)
+    Pkg.precompile(temp_ctx; io=ctx.io)
+
     write_env(temp_ctx.env; update_undo=false)
 
     return Base.active_project()

--- a/src/julia-1.9/common.jl
+++ b/src/julia-1.9/common.jl
@@ -22,7 +22,7 @@ function ctx_and_pkgspec(pkg::AbstractString)
     pkgspec = deepcopy(PackageSpec(pkg))
     ctx = Context()
     isinstalled!(ctx, pkgspec) || throw(TestEnvError("$pkg not installed 👻"))
-    Pkg.instantiate(ctx)
+    Pkg.instantiate(ctx; allow_autoprecomp = false) # do precomp later within sandbox
     return ctx, pkgspec
 end
 


### PR DESCRIPTION
Fixes https://github.com/JuliaTesting/TestEnv.jl/issues/89.

Woohoo! :) It seems to work now! :)

@davidanthoff: This should also make testing subpackages faster in VSCode as well, not just for ReTestItems.

-----------

I'm happy to clone 1.9 into a 1.10 directory, and make this change there, but it doesn't seem to _hurt_ anything on older versions so it seems like we can keep things as-is?
