### PR TITLE
Fix activating [sources] with relative paths

### DIFF
--- a/test/activate_set.jl
+++ b/test/activate_set.jl
@@ -86,4 +86,24 @@
             @test isdefined(TestEnv, :isfixed)
         end
     end
+
+    if VERSION >= v"1.11"
+        @testset "activate with [sources]" begin
+            orig_project_toml_path = Base.active_project()
+            push!(LOAD_PATH, mktempdir())  # put something weird in LOAD_PATH for testing
+            orig_load_path = Base.LOAD_PATH
+            try
+                Pkg.activate(joinpath(@__DIR__, "sources", "MainEnv"))
+                TestEnv.activate()
+                new_project_toml_path = Base.active_project()
+                @test new_project_toml_path != orig_project_toml_path
+                @test orig_load_path == Base.LOAD_PATH
+                @eval using MainEnv
+                @test isdefined(@__MODULE__, :MainEnv)
+                @test MainEnv.bar() == 42
+            finally
+                Pkg.activate(orig_project_toml_path)
+            end
+        end
+    end
 end

--- a/test/sources/DependentEnv/Project.toml
+++ b/test/sources/DependentEnv/Project.toml
@@ -1,0 +1,12 @@
+name = "DependentEnv"
+uuid = "c9261501-a1a4-4a21-a37c-0c7025a0fef8"
+version = "0.0.0"
+
+[deps]
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/test/sources/DependentEnv/src/DependentEnv.jl
+++ b/test/sources/DependentEnv/src/DependentEnv.jl
@@ -1,0 +1,6 @@
+module DependentEnv
+using JSON
+
+foo() = 40
+
+end

--- a/test/sources/MainEnv/Project.toml
+++ b/test/sources/MainEnv/Project.toml
@@ -1,0 +1,16 @@
+name = "MainEnv"
+uuid = "1b324c26-e66a-4bf4-9aeb-d8ecf06e8e93"
+version = "0.0.0"
+
+[deps]
+DependentEnv = "c9261501-a1a4-4a21-a37c-0c7025a0fef8"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+
+[sources]
+DependentEnv = {path = "../DependentEnv"}
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/test/sources/MainEnv/src/MainEnv.jl
+++ b/test/sources/MainEnv/src/MainEnv.jl
@@ -1,0 +1,6 @@
+module MainEnv
+using DependentEnv
+
+bar() = DependentEnv.foo() + 2
+
+end

--- a/test/sources/MainEnv/test/runtests.jl
+++ b/test/sources/MainEnv/test/runtests.jl
@@ -1,0 +1,4 @@
+using MainEnv
+using Test
+
+@test MainEnv.bar() == 42


### PR DESCRIPTION
So.. a very rough attempt to fix #92. Basically, the idea is to just loop over the source `Project.toml` and replace the relative paths with absolute paths, before it gets resolved.

Seems to work, but I really don't follow the code well enough to know if it's in the right place. Or even the right solution.

cc @KristofferC, should you have any bandwith to take a look at this.