### PR TITLE
Adapt `Pkg.Operations.prune_manifest` call for 1.12

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TestEnv"
 uuid = "1e6cf692-eddd-4d53-88a5-2d735e33781b"
-version = "1.102.1"
+version = "1.102.2"
 
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/src/julia-1.11/activate_set.jl
+++ b/src/julia-1.11/activate_set.jl
@@ -37,6 +37,7 @@ function activate(pkg::AbstractString=current_pkg_name(); allow_reresolve=true)
     for (name, uuid) in sandbox_env.project.deps
         entry = get(sandbox_manifest, uuid, nothing)
         if entry !== nothing && isfixed(entry)
+            # Signature changed when workspaces were introduced to Pkg in v1.12 (see Pkg.jl#3841)
             subgraph = Pkg.Operations.prune_manifest(sandbox_manifest, VERSION < v"1.12.0-" ? [uuid] : Set([uuid]))
             for (uuid, entry) in subgraph
                 if haskey(working_manifest, uuid)

--- a/src/julia-1.11/activate_set.jl
+++ b/src/julia-1.11/activate_set.jl
@@ -37,7 +37,7 @@ function activate(pkg::AbstractString=current_pkg_name(); allow_reresolve=true)
     for (name, uuid) in sandbox_env.project.deps
         entry = get(sandbox_manifest, uuid, nothing)
         if entry !== nothing && isfixed(entry)
-            subgraph = Pkg.Operations.prune_manifest(sandbox_manifest, [uuid])
+            subgraph = Pkg.Operations.prune_manifest(sandbox_manifest, VERSION < v"1.12.0-" ? [uuid] : Set([uuid]))
             for (uuid, entry) in subgraph
                 if haskey(working_manifest, uuid)
                     Pkg.Operations.pkgerror("can not merge projects")


### PR DESCRIPTION
The signature of the function has changed when workspaces were introduced to `Pkg` [(diff)](https://github.com/JuliaLang/Pkg.jl/commit/162634c5615d12b889e4b64f3cff95d1c377f189#diff-6dfb4e40705b22a427451362ea83b4e3a763028e3dcaa3b9b1846aa1ec84370fL955-R1034)