### PR TITLE
Fix TestEnv for subpackages: precompile only the new test Project, take 2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TestEnv"
 uuid = "1e6cf692-eddd-4d53-88a5-2d735e33781b"
-version = "1.103.4"
+version = "1.103.5"
 
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/src/julia-1.11/activate_set.jl
+++ b/src/julia-1.11/activate_set.jl
@@ -84,6 +84,11 @@ function activate(pkg::AbstractString=current_pkg_name(); allow_reresolve=true)
         @debug "Using _clean_ dep graph"
     end
 
+    # Now that we have set up the sandbox environment, precompile all its packages:
+    # (Reconnect the `io` back to the original context so the caller can see the
+    # precompilation progress.)
+    Pkg._auto_precompile(temp_ctx; already_instantiated=true)
+
     write_env(temp_ctx.env; update_undo=false)
 
     return Base.active_project()

--- a/src/julia-1.11/common.jl
+++ b/src/julia-1.11/common.jl
@@ -22,7 +22,7 @@ function ctx_and_pkgspec(pkg::AbstractString)
     pkgspec = deepcopy(PackageSpec(pkg))
     ctx = Context()
     isinstalled!(ctx, pkgspec) || throw(TestEnvError("$pkg not installed 👻"))
-    Pkg.instantiate(ctx)
+    Pkg.instantiate(ctx; allow_autoprecomp=false)
     return ctx, pkgspec
 end
 

--- a/src/julia-1.12/activate_set.jl
+++ b/src/julia-1.12/activate_set.jl
@@ -84,6 +84,11 @@ function activate(pkg::AbstractString=current_pkg_name(); allow_reresolve=true)
         @debug "Using _clean_ dep graph"
     end
 
+    # Now that we have set up the sandbox environment, precompile all its packages:
+    # (Reconnect the `io` back to the original context so the caller can see the
+    # precompilation progress.)
+    Pkg._auto_precompile(temp_ctx; already_instantiated=true)
+
     write_env(temp_ctx.env; update_undo=false)
 
     return Base.active_project()

--- a/src/julia-1.12/common.jl
+++ b/src/julia-1.12/common.jl
@@ -22,7 +22,7 @@ function ctx_and_pkgspec(pkg::AbstractString)
     pkgspec = deepcopy(PackageSpec(pkg))
     ctx = Context()
     isinstalled!(ctx, pkgspec) || throw(TestEnvError("$pkg not installed 👻"))
-    Pkg.instantiate(ctx)
+    Pkg.instantiate(ctx; allow_autoprecomp=false)
     return ctx, pkgspec
 end
 

--- a/src/julia-1.13/activate_set.jl
+++ b/src/julia-1.13/activate_set.jl
@@ -84,6 +84,11 @@ function activate(pkg::AbstractString=current_pkg_name(); allow_reresolve=true)
         @debug "Using _clean_ dep graph"
     end
 
+    # Now that we have set up the sandbox environment, precompile all its packages:
+    # (Reconnect the `io` back to the original context so the caller can see the
+    # precompilation progress.)
+    Pkg._auto_precompile(temp_ctx; already_instantiated=true)
+
     write_env(temp_ctx.env; update_undo=false)
 
     return Base.active_project()

--- a/src/julia-1.13/common.jl
+++ b/src/julia-1.13/common.jl
@@ -22,7 +22,7 @@ function ctx_and_pkgspec(pkg::AbstractString)
     pkgspec = deepcopy(PackageSpec(pkg))
     ctx = Context()
     isinstalled!(ctx, pkgspec) || throw(TestEnvError("$pkg not installed 👻"))
-    Pkg.instantiate(ctx)
+    Pkg.instantiate(ctx; allow_autoprecomp=false)
     return ctx, pkgspec
 end
 

--- a/src/julia-1.9/activate_set.jl
+++ b/src/julia-1.9/activate_set.jl
@@ -69,6 +69,11 @@ function activate(pkg::AbstractString=current_pkg_name(); allow_reresolve=true)
         @debug "Using _clean_ dep graph"
     end
 
+    # Now that we have set up the sandbox environment, precompile all its packages:
+    # (Reconnect the `io` back to the original context so the caller can see the
+    # precompilation progress.)
+    Pkg._auto_precompile(temp_ctx; already_instantiated=true)
+
     write_env(temp_ctx.env; update_undo=false)
 
     return Base.active_project()

--- a/src/julia-1.9/common.jl
+++ b/src/julia-1.9/common.jl
@@ -22,7 +22,7 @@ function ctx_and_pkgspec(pkg::AbstractString)
     pkgspec = deepcopy(PackageSpec(pkg))
     ctx = Context()
     isinstalled!(ctx, pkgspec) || throw(TestEnvError("$pkg not installed 👻"))
-    Pkg.instantiate(ctx)
+    Pkg.instantiate(ctx; allow_autoprecomp=false)
     return ctx, pkgspec
 end
 

--- a/test/activate_set.jl
+++ b/test/activate_set.jl
@@ -5,13 +5,12 @@
             Pkg.add(PackageSpec(name="ChainRulesCore", version="1.0.2"))
 
             orig_project_toml_path = Base.active_project()
+            orig_load_path = copy(LOAD_PATH)
             push!(LOAD_PATH, mktempdir())  # put something weird in LOAD_PATH for testing
-            orig_load_path = Base.LOAD_PATH
             try
                 TestEnv.activate("ChainRulesCore")
                 new_project_toml_path = Base.active_project()
                 @test new_project_toml_path != orig_project_toml_path
-                @test orig_load_path == Base.LOAD_PATH
 
                 @eval using StaticArrays  # From ChainRulesCore [extras] Project.toml
                 @test Base.invokelatest(isdefined, @__MODULE__, :StaticArrays)
@@ -22,6 +21,8 @@
                 Pkg.activate(orig_project_toml_path)
                 # No longer is enviroment active
                 @test_throws ArgumentError @eval using OffsetArrays
+                pop!(LOAD_PATH)
+                @test orig_load_path == LOAD_PATH
             end
         end
     end
@@ -34,8 +35,8 @@
                 Pkg.add(PackageSpec(name="YAXArrays", version="0.1.3"))
 
                 orig_project_toml_path = Base.active_project()
+                orig_load_path = copy(LOAD_PATH)
                 push!(LOAD_PATH, mktempdir())  # put something weird in LOAD_PATH for testing
-                orig_load_path = Base.LOAD_PATH
                 try
                     # YAXArrays has a test/Project.toml, which contains CSV
                     if VERSION >= v"1.8-"
@@ -46,20 +47,21 @@
                     TestEnv.activate("YAXArrays"; kw...)
                     new_project_toml_path = Base.active_project()
                     @test new_project_toml_path != orig_project_toml_path
-                    @test orig_load_path == Base.LOAD_PATH
 
                     @eval using CSV
                     @test Base.invokelatest(isdefined, @__MODULE__, :CSV)
 
                 finally
                     Pkg.activate(orig_project_toml_path)
+                    pop!(LOAD_PATH)
+                    @test orig_load_path == LOAD_PATH
                 end
             elseif VERSION >= v"1.2-"
                 Pkg.add(PackageSpec(name="ConstraintSolver", version="0.6.10"))
 
                 orig_project_toml_path = Base.active_project()
+                orig_load_path = copy(LOAD_PATH)
                 push!(LOAD_PATH, mktempdir())  # put something weird in LOAD_PATH for testing
-                orig_load_path = Base.LOAD_PATH
                 try
                     # ConstraintSolver has a test/Project.toml, which contains CSV
                     if VERSION >= v"1.8-"
@@ -70,13 +72,14 @@
                     TestEnv.activate("ConstraintSolver"; kw...)
                     new_project_toml_path = Base.active_project()
                     @test new_project_toml_path != orig_project_toml_path
-                    @test orig_load_path == Base.LOAD_PATH
 
                     @eval using JSON
                     @test Base.invokelatest(isdefined, @__MODULE__, :JSON)
 
                 finally
                     Pkg.activate(orig_project_toml_path)
+                    pop!(LOAD_PATH)
+                    @test orig_load_path == LOAD_PATH
                 end
             end
         end
@@ -90,36 +93,38 @@
     if VERSION >= v"1.11"
         @testset "activate with [sources]" begin
             orig_project_toml_path = Base.active_project()
+            orig_load_path = copy(LOAD_PATH)
             push!(LOAD_PATH, mktempdir())  # put something weird in LOAD_PATH for testing
-            orig_load_path = Base.LOAD_PATH
             try
                 Pkg.activate(joinpath(@__DIR__, "sources", "MainEnv"))
                 TestEnv.activate()
                 new_project_toml_path = Base.active_project()
                 @test new_project_toml_path != orig_project_toml_path
-                @test orig_load_path == Base.LOAD_PATH
                 @eval using MainEnv
                 @test isdefined(@__MODULE__, :MainEnv)
                 @test MainEnv.bar() == 42
             finally
                 Pkg.activate(orig_project_toml_path)
+                pop!(LOAD_PATH)
+                @test orig_load_path == LOAD_PATH
             end
         end
         @testset "activate with [sources] and two Project.toml approach" begin
             orig_project_toml_path = Base.active_project()
+            orig_load_path = copy(LOAD_PATH)
             push!(LOAD_PATH, mktempdir())  # put something weird in LOAD_PATH for testing
-            orig_load_path = Base.LOAD_PATH
             try
                 Pkg.activate(joinpath(@__DIR__, "sources", "MainTestProjectEnv"))
                 TestEnv.activate()
                 new_project_toml_path = Base.active_project()
                 @test new_project_toml_path != orig_project_toml_path
-                @test orig_load_path == Base.LOAD_PATH
                 @eval using MainTestProjectEnv
                 @test isdefined(@__MODULE__, :MainTestProjectEnv)
                 @test MainTestProjectEnv.bar() == 42
             finally
                 Pkg.activate(orig_project_toml_path)
+                pop!(LOAD_PATH)
+                @test orig_load_path == LOAD_PATH
             end
         end
     end
@@ -127,19 +132,70 @@
     if VERSION >= v"1.12-"
         @testset "activate [workspace] test env" begin
             orig_project_toml_path = Base.active_project()
+            orig_load_path = copy(LOAD_PATH)
             push!(LOAD_PATH, mktempdir())  # put something weird in LOAD_PATH for testing
-            orig_load_path = Base.LOAD_PATH
             try
                 Pkg.activate(joinpath(@__DIR__, "sources", "WorkspaceTestEnv"))
                 TestEnv.activate()
                 new_project_toml_path = Base.active_project()
                 @test new_project_toml_path != orig_project_toml_path
-                @test orig_load_path == Base.LOAD_PATH
                 @eval using WorkspaceTestEnv
                 @test isdefined(@__MODULE__, :WorkspaceTestEnv)
                 @test WorkspaceTestEnv.foo() == 42
             finally
                 Pkg.activate(orig_project_toml_path)
+                pop!(LOAD_PATH)
+                @test orig_load_path == LOAD_PATH
+            end
+        end
+    end
+
+    if VERSION >= v"1.6" # JULIA_PKG_PRECOMPILE_AUTO was introduced in 1.6
+        @testset "JULIA_PKG_PRECOMPILE_AUTO compatibility" begin
+            mktempdir() do p
+                withenv("JULIA_PKG_PRECOMPILE_AUTO" => "0") do
+                    orig_load_path = copy(LOAD_PATH)
+                    push!(empty!(LOAD_PATH), p)
+
+                    # Restrict the depot path to avoid grabbing a precompiled version from a
+                    # stacked environment
+                    orig_depot_path = copy(DEPOT_PATH)
+                    push!(empty!(DEPOT_PATH), mkdir(joinpath(p, ".julia")))
+
+                    try
+                        Pkg.activate(p)
+                        orig_project_toml_path = Base.active_project()
+                        try
+                            Pkg.develop(PackageSpec(path=pkgdir(TestEnv)))
+                            Pkg.add(PackageSpec(name="Example"))
+                            try
+                                TestEnv.activate("Example")
+                                if VERSION < v"1.10" # Base.isprecompiled was added in 1.10
+                                    cache_dir = Base.compilecache_dir(Base.identify_package("Example"))
+                                    @test !isdir(cache_dir) || isempty(readdir(cache_dir))
+                                else
+                                    @test !Base.isprecompiled(Base.identify_package("Example"))
+                                end
+                            catch e
+                                @error "Error during TestEnv.activate/isprecompiled check" exception=(e, catch_backtrace())
+                                @test false
+                            end
+                            new_project_toml_path = Base.active_project()
+                            @test new_project_toml_path != orig_project_toml_path
+                        finally
+                            Pkg.activate(orig_project_toml_path)
+                        end
+                    finally
+                        if isdefined(@__MODULE__, :orig_load_path)
+                            pop!(LOAD_PATH)
+                            append!(LOAD_PATH, orig_load_path)
+                        end
+                        if isdefined(@__MODULE__, :orig_depot_path)
+                            pop!(DEPOT_PATH)
+                            append!(DEPOT_PATH, orig_depot_path)
+                        end
+                    end
+                end
             end
         end
     end


### PR DESCRIPTION
Like https://github.com/JuliaTesting/TestEnv.jl/pull/90, but uses `Pkg._auto_precompile` instead of `Pkg.precompile` to respect the `JULIA_PKG_PRECOMPILE_AUTO` env var.