### PR TITLE
Port merge-project guard to Julia 1.4-1.10 variants

### DIFF
--- a/src/julia-1.4/activate_set.jl
+++ b/src/julia-1.4/activate_set.jl
@@ -37,7 +37,8 @@ function activate(pkg::AbstractString=current_pkg_name())
         if entry !== nothing && isfixed(entry)
             subgraph = Pkg.Operations.prune_manifest(sandbox_manifest, [uuid])
             for (uuid, entry) in subgraph
-                if haskey(working_manifest, uuid)
+                entry_working = get(working_manifest, uuid, nothing)
+                if entry_working !== nothing && entry_working != entry && (ctx.env.pkg !== nothing && ctx.env.pkg.uuid != uuid)
                     Pkg.Operations.pkgerror("can not merge projects")
                 end
                 working_manifest[uuid] = entry

--- a/src/julia-1.7/activate_set.jl
+++ b/src/julia-1.7/activate_set.jl
@@ -39,7 +39,8 @@ function activate(pkg::AbstractString=current_pkg_name())
         if entry !== nothing && isfixed(entry)
             subgraph = Pkg.Operations.prune_manifest(sandbox_manifest, [uuid])
             for (uuid, entry) in subgraph
-                if haskey(working_manifest, uuid)
+                entry_working = get(working_manifest, uuid, nothing)
+                if entry_working !== nothing && entry_working != entry && (ctx.env.pkg !== nothing && ctx.env.pkg.uuid != uuid)
                     Pkg.Operations.pkgerror("can not merge projects")
                 end
                 working_manifest[uuid] = entry

--- a/src/julia-1.8/activate_set.jl
+++ b/src/julia-1.8/activate_set.jl
@@ -39,7 +39,8 @@ function activate(pkg::AbstractString=current_pkg_name(); allow_reresolve=true)
         if entry !== nothing && isfixed(entry)
             subgraph = Pkg.Operations.prune_manifest(sandbox_manifest, [uuid])
             for (uuid, entry) in subgraph
-                if haskey(working_manifest, uuid)
+                entry_working = get(working_manifest, uuid, nothing)
+                if entry_working !== nothing && entry_working != entry && (ctx.env.pkg !== nothing && ctx.env.pkg.uuid != uuid)
                     Pkg.Operations.pkgerror("can not merge projects")
                 end
                 working_manifest[uuid] = entry

--- a/src/julia-1.9/activate_set.jl
+++ b/src/julia-1.9/activate_set.jl
@@ -39,7 +39,8 @@ function activate(pkg::AbstractString=current_pkg_name(); allow_reresolve=true)
         if entry !== nothing && isfixed(entry)
             subgraph = Pkg.Operations.prune_manifest(sandbox_manifest, [uuid])
             for (uuid, entry) in subgraph
-                if haskey(working_manifest, uuid)
+                entry_working = get(working_manifest, uuid, nothing)
+                if entry_working !== nothing && entry_working != entry && (ctx.env.pkg !== nothing && ctx.env.pkg.uuid != uuid)
                     Pkg.Operations.pkgerror("can not merge projects")
                 end
                 working_manifest[uuid] = entry

--- a/test/activate_set.jl
+++ b/test/activate_set.jl
@@ -90,6 +90,43 @@
         end
     end
 
+    if VERSION >= v"1.4-"
+        # https://github.com/JuliaTesting/TestEnv.jl/pull/120
+        # A package whose `test/Manifest.toml` dev's the package itself, i.e. what
+        # `julia --project=test -e 'using Pkg; Pkg.develop(path=".")'` produces.
+        @testset "activate package dev'ed in its own test/Manifest" begin
+            mktempdir() do p
+                pkg_path = joinpath(p, "SelfDevTestManifest")
+                cp(joinpath(@__DIR__, "sources", "SelfDevTestManifest"), pkg_path)
+
+                orig_project_toml_path = Base.active_project()
+                orig_load_path = copy(LOAD_PATH)
+                push!(LOAD_PATH, mktempdir())  # put something weird in LOAD_PATH for testing
+                try
+                    # Generate the test/Manifest.toml that dev's the package itself
+                    Pkg.activate(joinpath(pkg_path, "test"))
+                    Pkg.develop(PackageSpec(path=pkg_path))
+
+                    # ... and the package's own manifest
+                    Pkg.activate(pkg_path)
+                    Pkg.resolve()
+
+                    TestEnv.activate()
+                    new_project_toml_path = Base.active_project()
+                    @test new_project_toml_path != orig_project_toml_path
+
+                    @eval using SelfDevTestManifest
+                    @test Base.invokelatest(isdefined, @__MODULE__, :SelfDevTestManifest)
+                    @test (@eval SelfDevTestManifest.foo()) == 42
+                finally
+                    Pkg.activate(orig_project_toml_path)
+                    pop!(LOAD_PATH)
+                    @test orig_load_path == LOAD_PATH
+                end
+            end
+        end
+    end
+
     if VERSION >= v"1.11"
         @testset "activate with [sources]" begin
             orig_project_toml_path = Base.active_project()

--- a/test/activate_set.jl
+++ b/test/activate_set.jl
@@ -103,7 +103,12 @@
                 orig_load_path = copy(LOAD_PATH)
                 push!(LOAD_PATH, mktempdir())  # put something weird in LOAD_PATH for testing
                 try
-                    # Generate the test/Manifest.toml that dev's the package itself
+                    # Both manifests are generated here rather than checked in with the
+                    # fixture, so that the manifest format always matches the running Julia
+                    # version and this test works on all of them. The `sources/*` fixtures
+                    # that do ship a Manifest.toml are only usable by the
+                    # `VERSION >= v"1.11"` testsets below; this one has to work back to 1.4.
+                    # First the test/Manifest.toml that dev's the package itself...
                     Pkg.activate(joinpath(pkg_path, "test"))
                     Pkg.develop(PackageSpec(path=pkg_path))
 

--- a/test/sources/SelfDevTestManifest/Project.toml
+++ b/test/sources/SelfDevTestManifest/Project.toml
@@ -1,0 +1,3 @@
+name = "SelfDevTestManifest"
+uuid = "1cda0850-20f2-4a85-a119-95c26fe5cbc8"
+version = "0.0.0"

--- a/test/sources/SelfDevTestManifest/src/SelfDevTestManifest.jl
+++ b/test/sources/SelfDevTestManifest/src/SelfDevTestManifest.jl
@@ -1,0 +1,5 @@
+module SelfDevTestManifest
+
+foo() = 42
+
+end

--- a/test/sources/SelfDevTestManifest/test/Project.toml
+++ b/test/sources/SelfDevTestManifest/test/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+SelfDevTestManifest = "1cda0850-20f2-4a85-a119-95c26fe5cbc8"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/sources/SelfDevTestManifest/test/runtests.jl
+++ b/test/sources/SelfDevTestManifest/test/runtests.jl
@@ -1,0 +1,4 @@
+using SelfDevTestManifest
+using Test
+
+@test SelfDevTestManifest.foo() == 42


### PR DESCRIPTION
## Summary

`src/julia-1.11/activate_set.jl` (and the 1.12/1.13 copies) guard the "can not merge projects" error when merging the test manifest into the package manifest:

```julia
entry_working = get(working_manifest, uuid, nothing)
if entry_working !== nothing && entry_working != entry && (ctx.env.pkg !== nothing && ctx.env.pkg.uuid != uuid)
    Pkg.Operations.pkgerror("can not merge projects")
end
```

The `julia-1.4`, `julia-1.7`, `julia-1.8` and `julia-1.9` variants still use the unconditional `if haskey(working_manifest, uuid) pkgerror("can not merge projects") end`. This PR ports the 1.11 guard to those four files verbatim (the `prune_manifest(sandbox_manifest, [uuid])` call is left as-is; the `Set([uuid])` signature is only 1.12+). `julia-1.0..1.3` do not have the merge loop and are untouched. Nothing else changes.

## Reproducer

A package with a `test/Project.toml` that lists the package itself and a `test/Manifest.toml` that dev's it (what `julia --project=test -e 'using Pkg; Pkg.develop(path=".")'` inside the package produces):

```toml
[[deps.MyPkg]]
path = ".."
uuid = "..."
version = "0.1.0"
```

On Julia 1.10, `julia --project=. -e 'using TestEnv; TestEnv.activate()'` fails with `can not merge projects`, because the package's own uuid is already in the working manifest (it is the package under test) and the fixed subgraph copied from the test manifest contains it again. On Julia 1.11+ the same layout activates fine. With this change it also activates on 1.10 (verified with 1.10.12).

This is the failure users of the VS Code extension's test item runner see on Julia <= 1.10, see julia-vscode/julia-vscode#3832 and julia-vscode/julia-vscode#3633.

## Tests

- `Pkg.test()` of this package on Julia 1.10.12: 18/18 pass.
- Manual reproducer above passes on 1.10.12 with this branch and fails on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
